### PR TITLE
Update colorspeedbutton.pas

### DIFF
--- a/colorspeedbutton.pas
+++ b/colorspeedbutton.pas
@@ -557,7 +557,7 @@ begin
   if Toggle then
     Pressed := not Pressed;
 
-  if PopupMode then
+  if PopupMode and Assigned(PopupMenu) then
   begin
     p := Parent.ClientToScreen(Point(Left, Top));
     PopupMenu.PopUp(p.x, p.y + Height);


### PR DESCRIPTION
Found a small issue if the Property PopupMode is TRUE, and no PupupMenu is set, will toss an exception.

Not sure if the prevailing wind wants to see the exception or do nothing like this patch.

Also PopupMode seems redundant as if a Popup is set, it could just imply that mode. Just learning a bit of some of these controls so may be historical or other reason.