### PR TITLE
Probable fix for issue "BCTrackbarUpdown control bug"

### DIFF
--- a/bccombobox.pas
+++ b/bccombobox.pas
@@ -681,11 +681,9 @@ end;
 procedure TBCComboBox.UpdateFocus(AFocused: boolean);
 var
   lForm: TCustomForm;
-  oldCaption: string;
 begin
   lForm := GetParentForm(Self);
-  if lForm = nil then
-    exit;
+  if lForm = nil then Exit;
 
   {$IFDEF FPC}//#
   if AFocused then
@@ -693,11 +691,6 @@ begin
   else
     ActiveDefaultControlChanged(nil);
   {$ENDIF}
-
-  oldCaption := FButton.Caption;
-  FButton.Caption := FButton.Caption + '1';
-  FButton.Caption := oldCaption;
-
   Invalidate;
 end;
 

--- a/bccombobox.pas
+++ b/bccombobox.pas
@@ -143,7 +143,7 @@ type
     property ArrowWidth: integer read GetArrowWidth write SetArrowWidth;
     property ArrowFlip: boolean read GetArrowFlip write SetArrowFlip default false;
     property FocusBorderColor: TColor read FFocusBorderColor write FFocusBorderColor default clBlack;
-    property FocusBorderOpacity: byte read FFocusBorderOpacity write FFocusBorderOpacity default 255;
+    property FocusBorderOpacity: byte read FFocusBorderOpacity write FFocusBorderOpacity default 0;
     property DropDownBorderColor: TColor read FDropDownBorderColor write FDropDownBorderColor default clWindowText;
     property DropDownBorderSize: integer read FDropDownBorderSize write FDropDownBorderSize default 1;
     property DropDownColor: TColor read GetDropDownColor write SetDropDownColor default clWindow;
@@ -440,17 +440,22 @@ end;
 procedure TBCComboBox.OnAfterRenderButton(Sender: TObject;
   const ABGRA: TBGRABitmap; AState: TBCButtonState; ARect: TRect);
 var
-  focusMargin: integer;
+  FocusMargin: integer;
 begin
   if Assigned(FOnDrawSelectedItem) then
     FOnDrawSelectedItem(self, ABGRA, AState, ARect);
   if Focused then
   begin
-    focusMargin := round(2 * Button.CanvasScale);
-    ABGRA.RectangleAntialias(ARect.Left + focusMargin, ARect.Top + focusMargin,
-      ARect.Right - focusMargin - 1, ARect.Bottom - focusMargin - 1,
-      ColorToBGRA(FocusBorderColor, FocusBorderOpacity),
-      Button.CanvasScale);
+    FocusMargin := round(2 * FButton.CanvasScale);
+    ABGRA.RoundRectAntialias(
+      ARect.Left + FocusMargin,
+      ARect.Top + FocusMargin,
+      ARect.Right - FocusMargin - 1,
+      ARect.Bottom - FocusMargin - 1,
+      Max(0, FButton.Rounding.RoundX - FocusMargin),
+      Max(0, FButton.Rounding.RoundY - FocusMargin),
+      ColorToBGRA(FFocusBorderColor, FFocusBorderOpacity),
+      FButton.CanvasScale);
   end;
 end;
 
@@ -822,6 +827,8 @@ begin
   FButton.OnClick := ButtonClick;
   FButton.DropDownArrow := True;
   FButton.OnAfterRenderBCButton := OnAfterRenderButton;
+  FFocusBorderColor := clBlack;
+  FFocusBorderOpacity := 0;
   UpdateButtonCanvasScaleMode;
 
   FItems := TStringList.Create;

--- a/bccombobox.pas
+++ b/bccombobox.pas
@@ -691,6 +691,7 @@ begin
   else
     ActiveDefaultControlChanged(nil);
   {$ENDIF}
+  FButton.UpdateControl;
   Invalidate;
 end;
 

--- a/bctrackbarupdown.pas
+++ b/bctrackbarupdown.pas
@@ -296,7 +296,7 @@ begin
   FEmptyText:= false;
   DoSelectAll;
   Invalidate;
-  NotifyChange;
+  if not (csLoading in ComponentState) then NotifyChange;
 end;
 
 procedure TCustomBCTrackbarUpdown.SetArrowColor(AValue: TColor);


### PR DESCRIPTION
By examining the source code of the standard component TTrackBar:
```
procedure TCustomTrackBar.SetPosition(Value: Integer);
begin
  FixParams(Value, FMin, FMax);
  if FPosition <> Value then
  begin
    FPosition := Value;
    if HandleAllocated then
      TWSTrackBarClass(WidgetSetClass).SetPosition(Self, FPosition);
    if not (csLoading in ComponentState) then 
      Changed;
  end;
end;
```
we can see the line

`if not (csLoading in ComponentState) then`

which prevents the OnChange event from being called unexpectedly during startup. 
I believe this is the anomalous behavior mentioned by the user in issue #115.

#### Edit:

Commit 2608140398fadbb59e584a440158bd7a8ea0adf5 fixes issue #120.
Code for drawing focus border was correctly called but opacity was always reset to zero on start.

Regards
Melchiorre