### PR TITLE
Added missing OnDblClick to ProgressBars

### DIFF
--- a/bcradialprogressbar.pas
+++ b/bcradialprogressbar.pas
@@ -3,6 +3,8 @@
 - Edivando S. Santos Brasil | mailedivando@gmail.com
   (Compatibility with delphi VCL 11/2018)
 
+- Sandy Ganz (sganz@pacbell.net)
+    2025-07  Added Missing OnDblClick event property
 ***************************** END CONTRIBUTOR(S) *****************************}
 unit BCRadialProgressBar;
 
@@ -68,6 +70,7 @@ type
     property MaxValue: integer read FMaxValue write SetMaxValue default 100;
     property Value: integer read FValue write SetValue default 0;
     property OnClick;
+    property OnDblClick;
     property OnMouseDown;
     property OnMouseEnter;
     property OnMouseLeave;

--- a/bgraflashprogressbar.pas
+++ b/bgraflashprogressbar.pas
@@ -24,6 +24,9 @@
              Added ShowBarAnimation
     2025-02  Added use of Font.Color
     2025-03  Added MarqueeWidthType
+
+- Sandy Ganz (sganz@pacbell.net)
+    2025-07  Added Missing OnDblClick event property
 ***************************** END CONTRIBUTOR(S) *****************************}
 unit BGRAFlashProgressBar;
 
@@ -248,6 +251,7 @@ type
     property GraphYLineDigits: Integer read FGraphYLineDigits write SetGraphYLineDigits default 0;
 
     property OnClick;
+    property OnDblClick;
     property OnMouseDown;
     property OnMouseEnter;
     property OnMouseLeave;

--- a/bgrashape.pas
+++ b/bgrashape.pas
@@ -13,6 +13,9 @@
 - Edivando S. Santos Brasil | mailedivando@gmail.com
   (Compatibility with delphi VCL 11/2018)
 
+- Sandy Ganz (sganz@pacbell.net)
+    2025-07  Added capture for Fill and Border Gradient property changes so
+             repaint will happen.
 ***************************** END CONTRIBUTOR(S) *****************************}
 unit BGRAShape;
 
@@ -69,6 +72,8 @@ type
   protected
     { Protected declarations }
     procedure Paint; override;
+    procedure DoChangeGradient(ASender: TObject; AData: PtrInt);
+
   public
     { Public declarations }
     constructor Create(AOwner: TComponent); override;
@@ -134,6 +139,13 @@ end;
 {$ENDIF}
 
 { TBGRAShape }
+
+// Added to catch any TBCGradient changes for Border and Fill Gradient objects
+
+procedure TBGRAShape.DoChangeGradient(ASender: TObject; AData: PtrInt);
+begin
+  Invalidate;
+end;
 
 procedure TBGRAShape.SetBorderColor(const AValue: TColor);
 begin
@@ -397,10 +409,12 @@ begin
   FBorderGradient.Point2XPercent := 100;
   FBorderGradient.StartColor := clWhite;
   FBorderGradient.EndColor := clBlack;
+  FBorderGradient.OnChange := DoChangeGradient;
 
   FFillColor := clWindow;
   FFillOpacity := 255;
   FFillGradient := TBCGradient.Create(Self);
+  FFillGradient.OnChange := DoChangeGradient;
 
   FRoundRadius := 0;
   FSideCount := 4;


### PR DESCRIPTION
For Enhancement https://github.com/bgrabitmap/bgracontrols/issues/247 which a couple of progress bars were missing the OnDblClick published properties 


Also fix for https://github.com/bgrabitmap/bgracontrols/issues/250 by capturing changes to the Fill and Border Gradient to cause repaint on the TBGRAShape
