### PR TITLE
Updated AutoScale functionality and Test Program

### DIFF
--- a/supergauge.pas
+++ b/supergauge.pas
@@ -34,6 +34,9 @@ v2.00 - Breaking Changes from V1 SuperGauge Sandy Ganz, sganz@pacbell.net
         Removed unintended exposed property on RangeLED (OK to Remove from .lfm if warned)
         Changed RangeLED type of rcGaugeOutOfRange to rcGaugeOverload and events to
         make it language different then RangeCheckLED.
+v2.03 - Changed AutoScale functionality when NOT auto scaling to preserve the size
+        of the original component, so really no changes based on zoom/resolution.
+        This will alow it to draw correctly but possibly at a larger size when AutoScale is disabled.
 
 ******************************* END CHANGE LOG *******************************}
 
@@ -48,7 +51,7 @@ uses
   BGRABitmap, BGRABitmapTypes, BGRAVectorize, BGRAPath, math, bctypes, bctools;
 
 const
-  VERSIONSTR = '2.02';            // SG version, Should ALWAYS show as a delta when merging!
+  VERSIONSTR = '2.03';            // SG version, Should ALWAYS show as a delta when merging!
   INTERNAL_GAUGE_MIN_VALUE = 0;   // internal lowest value
   INTERNAL_GAUGE_MAX_VALUE = 270; // internal highest value
   BASELINE_SIZE = 300;            // For ResolveSizes()
@@ -206,7 +209,8 @@ type
 
   public
     { Public declarations }
-
+    procedure AutoAdjustLayout(AMode: TLayoutAdjustmentPolicy;
+          const AFromPPI, AToPPI, AOldFormWidth, ANewFormWidth: Integer); override;
     constructor Create(AOwner: TComponent); override;
     destructor Destroy; override;
 
@@ -334,6 +338,20 @@ end;
 {$ENDIF}
 
 { TSGCustomSuperGauge }
+procedure TSGCustomSuperGauge.AutoAdjustLayout(AMode: TLayoutAdjustmentPolicy;
+  const AFromPPI, AToPPI, AOldFormWidth, ANewFormWidth: Integer);
+begin
+  // If autoscaling then we will let the system mess with the component size
+  // otherwise it will just leave it along as the ACTUAL size in the designer
+  // as 1:1 with no scaling on anything. By not calling AutoAdjustLayout()
+  // Scaling will be 1:1
+  //
+  // Note - that toggling the AutoScale setting will cause a repaint
+  // but NOT a resize of the Components client area
+
+  if FAutoScale then
+    inherited AutoAdjustLayout(AMode, AFromPPI, AToPPI, AOldFormWidth, ANewFormWidth);
+end;
 
 constructor TSGCustomSuperGauge.Create(AOwner: TComponent);
 var

--- a/test/test_supergauge/sgtest.lfm
+++ b/test/test_supergauge/sgtest.lfm
@@ -4433,8 +4433,8 @@ object SGTestFrm: TSGTestFrm
         Height = 32
         Top = 32
         Width = 32
-        BorderColor = clBlack
         BorderThickness = 3
+        AutoScale = True
       end
       object TestLedShape: TBGRAShape
         Left = 40
@@ -5427,16 +5427,17 @@ object SGTestFrm: TSGTestFrm
       Font.Style = [fsBold]
       ParentFont = False
     end
-    object uELED2: TSuperLED
+    object SuperLED2: TSuperLED
       Left = 400
       Height = 36
       Hint = 'Gauge Overload/Underload Indicator'#13#10'Triggers if below min or above max value'
       Top = 160
       Width = 36
       BorderThickness = 3
+      AutoScale = True
       ShowHint = True
     end
-    object uELED1: TSuperLED
+    object SuperLED1: TSuperLED
       Left = 400
       Height = 36
       Hint = 'Random Mode Indicator'
@@ -5444,6 +5445,7 @@ object SGTestFrm: TSGTestFrm
       Width = 36
       ActiveColor = clLime
       BorderThickness = 3
+      AutoScale = True
       ShowHint = True
     end
   end

--- a/test/test_supergauge/sgtest.pas
+++ b/test/test_supergauge/sgtest.pas
@@ -14,6 +14,8 @@
 ***************************** END CONTRIBUTOR(S) *****************************}
 {******************************** CHANGE LOG *********************************
 v2.01 - Swapped uELED component with SuperLED component
+v2.02 - Updated LED component names, set LED's to use AutoScale, Minor other
+        fixes.
 ******************************* END CHANGE LOG *******************************}
 
 unit sgtest;
@@ -29,7 +31,7 @@ uses
   SuperGauge, SuperLED, about;
 
 const
-  VERSIONSTR = '2.01';            // SG TEST version, Should ALWAYS show as a delta when merging!
+  VERSIONSTR = '2.02';            // SG TEST version, Should ALWAYS show as a delta when merging!
 
 type
   { TSGTestFrm }
@@ -225,8 +227,8 @@ type
     Label3: TLabel;
     DispMinLbl: TLabel;
     DispMinValLbl: TLabel;
-    uELED1: TSuperLED;
-    uELED2: TSuperLED;
+    SuperLED1: TSuperLED;
+    SuperLED2: TSuperLED;
     ValuePlus1Btn: TBitBtn;
     ValueMinus1Btn: TBitBtn;
     ValuePlus10Btn: TBitBtn;
@@ -1220,6 +1222,7 @@ end;
 procedure TSGTestFrm.UpdateBasicStats;
 begin
   BackgroundColorCb.Selected := SuperGauge.Color;
+  AutoScaleCb.Checked := SuperGauge.AutoScale;
 end;
 
 procedure TSGTestFrm.UpdateLTStats;
@@ -1258,6 +1261,7 @@ begin
   // LED for testings.
   // Be Fancy and if setting LED as shaded do the same for the test
 
+  TestLedShape.Visible := not (SuperGauge.RangeLEDSettings.Style = lsNone);
   TestLEDShape.UseFillGradient := (SuperGauge.RangeLEDSettings.Style = lsShaded);
 
   case SuperGauge.RangeLEDSettings.Shape of
@@ -3040,7 +3044,7 @@ begin
   ResetLoTics := 10;                    // 10 forces update now unless timer stopped
   ResetHiTics := 10;
   Timer2.Enabled := not Timer2.Enabled; // toggle timer
-  uELED1.Active:=Timer2.Enabled;
+  SuperLED1.Active:=Timer2.Enabled;
 end;
 
 procedure TSGTestFrm.MarkerRandomTestBtnClick(Sender: TObject);
@@ -4066,7 +4070,7 @@ end;
 procedure TSGTestFrm.Timer1Timer(Sender: TObject);
 begin
   TimerState := not TimerState;
-  uELED2.Active := TimerState;
+  SuperLED2.Active := TimerState;
 
   if TimerState then
     begin


### PR DESCRIPTION
Added some code to force the component size to NOT autoscale at all. This will allow the component to render correctly (although larger) if autoscale is false and you have a high dpi monitor scaling things down. 

Test program gets some minor fixes, component name changes to remove the notion of ueLED since it's all SuperLED now. Also a couple of other minor things.