### PR TITLE
#265 fixing BCKeyboard key input

### DIFF
--- a/bckeyboard.pas
+++ b/bckeyboard.pas
@@ -7,6 +7,9 @@
 unit BCKeyboard;
 
 {$I bgracontrols.inc}
+{$IFDEF lclGTK2}
+  {$DEFINE PREVENTFOCUS}
+{$ENDIF}
 
 interface
 
@@ -36,7 +39,7 @@ type
     procedure SetFThemeManager(AValue: TBCThemeManager);
   protected
     FActiveControl: TWinControl;
-    {$IFDEF lclGTK2}procedure ScreenActiveControlChanged(Sender: TObject; LastControl: TControl); virtual;
+    {$IFDEF PREVENTFOCUS}procedure ScreenActiveControlChanged(Sender: TObject; LastControl: TControl); virtual;
     procedure ReactivateControl({%H-}Data: PtrInt);{$ENDIF}
     procedure PressVirtKey(AKeyCode: PtrInt);
     procedure PressShiftVirtKey(AKeyCode: PtrInt);
@@ -449,18 +452,22 @@ begin
   F_space.Parent := FRow4;
   F_space.OnMouseDown := OnButtonClick;
 
+  {$IFDEF PREVENTFOCUS}
   Screen.AddHandlerActiveControlChanged(ScreenActiveControlChanged);
+  {$ENDIF}
 end;
 
 destructor TBCKeyboard.Destroy;
 begin
+  {$IFDEF PREVENTFOCUS}
   Screen.RemoveHandlerActiveControlChanged(ScreenActiveControlChanged);
+  {$ENDIF}
   { Everything inside the panel will be freed }
   FPanel.Free;
   inherited Destroy;
 end;
 
-{$IFDEF lclGTK2}procedure TBCKeyboard.ScreenActiveControlChanged(Sender: TObject; LastControl: TControl);
+{$IFDEF PREVENTFOCUS}procedure TBCKeyboard.ScreenActiveControlChanged(Sender: TObject; LastControl: TControl);
 begin
   if (LastControl = nil) or (LastControl is TWinControl) then
   begin

--- a/bckeyboard.pas
+++ b/bckeyboard.pas
@@ -116,7 +116,9 @@ var
   cUtf8: TUTF8Char;
   {$ENDIF}
 begin
+  {$IFDEF LCLgtk2}
   LCLIntf.SendMessage(ATarget.Handle, CN_KEYDOWN, AKeyCode, 1);
+  {$ENDIF}
   LCLIntf.SendMessage(ATarget.Handle, LM_KEYDOWN, AKeyCode, 1);
   if TranslateKey(AKeyCode, AShift, c) then
   begin
@@ -126,7 +128,9 @@ begin
     ATarget.IntfUTF8KeyPress(cUtf8, 1, false);
     {$ENDIF}
   end;
+  {$IFDEF LCLgtk2}
   LCLIntf.SendMessage(ATarget.Handle, CN_KEYUP, AKeyCode, 1);
+  {$ENDIF}
   LCLIntf.SendMessage(ATarget.Handle, LM_KEYUP, AKeyCode, 1);
 end;
 

--- a/bckeyboard.pas
+++ b/bckeyboard.pas
@@ -33,13 +33,15 @@ type
     F_f, F_g, F_h, F_j, F_k, F_l, F_z, F_x, F_c, F_v, F_b, F_n, F_m,
     F_shift, F_space, F_back: TBCButton;
     FVisible: boolean;
+    function GetActiveControl: TWinControl;
     procedure SetFButton(AValue: TBCButton);
     procedure SetFPanel(AValue: TBCPanel);
     procedure SetFPanelsColor(AValue: TColor);
     procedure SetFThemeManager(AValue: TBCThemeManager);
   protected
+    {$IFDEF PREVENTFOCUS}
     FActiveControl: TWinControl;
-    {$IFDEF PREVENTFOCUS}procedure ScreenActiveControlChanged(Sender: TObject; LastControl: TControl); virtual;
+    procedure ScreenActiveControlChanged(Sender: TObject; LastControl: TControl); virtual;
     procedure ReactivateControl({%H-}Data: PtrInt);{$ENDIF}
     procedure PressVirtKey(AKeyCode: PtrInt);
     procedure PressShiftVirtKey(AKeyCode: PtrInt);
@@ -60,7 +62,7 @@ type
     procedure UpdateButtonStyle;
   public
     { The last active control besides this control }
-    property ActiveControl: TWinControl read FActiveControl;
+    property ActiveControl: TWinControl read GetActiveControl;
     { The real panel that's used as container for all the numeric buttons }
     property Panel: TBCPanel read FPanel write SetFPanel;
     { The color of all the panels involved in the control }
@@ -549,6 +551,15 @@ begin
   if FButton = AValue then
     Exit;
   FButton := AValue;
+end;
+
+function TBCKeyboard.GetActiveControl: TWinControl;
+begin
+  {$IFDEF PREVENTFOCUS}
+  result := FActiveControl;
+  {$ELSE}
+  result := Screen.ActiveControl;
+  {$ENDIF}
 end;
 
 procedure TBCKeyboard.SetFPanel(AValue: TBCPanel);

--- a/bckeyboard.pas
+++ b/bckeyboard.pas
@@ -35,8 +35,11 @@ type
     procedure SetFPanelsColor(AValue: TColor);
     procedure SetFThemeManager(AValue: TBCThemeManager);
   protected
-    procedure PressVirtKey(p: PtrInt);
-    procedure PressShiftVirtKey(p: PtrInt);
+    FActiveControl: TWinControl;
+    {$IFDEF lclGTK2}procedure ScreenActiveControlChanged(Sender: TObject; LastControl: TControl); virtual;
+    procedure ReactivateControl({%H-}Data: PtrInt);{$ENDIF}
+    procedure PressVirtKey(AKeyCode: PtrInt);
+    procedure PressShiftVirtKey(AKeyCode: PtrInt);
     procedure OnButtonClick(Sender: TObject; {%H-}Button: TMouseButton;
       {%H-}Shift: TShiftState; {%H-}X, {%H-}Y: integer); virtual;
     { When value is changed by the user }
@@ -53,6 +56,8 @@ type
     // Update buttons style
     procedure UpdateButtonStyle;
   public
+    { The last active control besides this control }
+    property ActiveControl: TWinControl read FActiveControl;
     { The real panel that's used as container for all the numeric buttons }
     property Panel: TBCPanel read FPanel write SetFPanel;
     { The color of all the panels involved in the control }
@@ -84,27 +89,60 @@ begin
   FBCThemeManager := AValue;
 end;
 
-procedure TBCKeyboard.PressVirtKey(p: PtrInt);
-var
-  Target: TWinControl;
+function TranslateKey(AKeyCode: PtrInt; AShift: boolean; out AChar: char): boolean;
 begin
-  Target := Screen.ActiveControl;
-  if Target = nil then Exit;
-
-  LCLIntf.SendMessage(Target.Handle, LM_KEYDOWN, p, 1);
-  LCLIntf.SendMessage(Target.Handle, LM_KEYUP, p, 1);
+  if (AKeyCode = VK_SPACE) or (AKeyCode = VK_BACK) or
+    ((AKeyCode >= VK_0) and (AKeyCode <= VK_9)) or
+    ((AKeyCode >= VK_A) and (AKeyCode <= VK_Z)) then
+  begin
+    result := true;
+    if AShift then
+      AChar := UpCase(chr(AKeyCode))
+    else
+      AChar := LowerCase(chr(AKeyCode));
+  end else
+    result := false;
 end;
 
-procedure TBCKeyboard.PressShiftVirtKey(p: PtrInt);
+procedure SendKeyPress(ATarget: TWinControl; AKeyCode: PtrInt; AShift: boolean);
+var
+  c: char;
+  {$IFDEF LCLgtk2}
+  cUtf8: TUTF8Char;
+  {$ENDIF}
+begin
+  LCLIntf.SendMessage(ATarget.Handle, CN_KEYDOWN, AKeyCode, 1);
+  LCLIntf.SendMessage(ATarget.Handle, LM_KEYDOWN, AKeyCode, 1);
+  if TranslateKey(AKeyCode, AShift, c) then
+  begin
+    LCLIntf.SendMessage(ATarget.Handle, LM_CHAR, ord(c), 0);
+    {$IFDEF LCLgtk2}
+    cUtf8 := c;
+    ATarget.IntfUTF8KeyPress(cUtf8, 1, false);
+    {$ENDIF}
+  end;
+  LCLIntf.SendMessage(ATarget.Handle, CN_KEYUP, AKeyCode, 1);
+  LCLIntf.SendMessage(ATarget.Handle, LM_KEYUP, AKeyCode, 1);
+end;
+
+procedure TBCKeyboard.PressVirtKey(AKeyCode: PtrInt);
 var
   Target: TWinControl;
 begin
-  Target := Screen.ActiveControl;
+  Target := ActiveControl;
+  if Target = nil then Exit;
+  SendKeyPress(Target, AKeyCode, false);
+end;
+
+procedure TBCKeyboard.PressShiftVirtKey(AKeyCode: PtrInt);
+var
+  Target: TWinControl;
+begin
+  Target := ActiveControl;
   if Target = nil then Exit;
 
   LCLIntf.SendMessage(Target.Handle, LM_KEYDOWN, VK_SHIFT, 1);
-  LCLIntf.SendMessage(Target.Handle, LM_KEYDOWN, p, 1);
-  LCLIntf.SendMessage(Target.Handle, LM_KEYUP, p, 1);
+  SendKeyPress(Target, AKeyCode, true);
   LCLIntf.SendMessage(Target.Handle, LM_KEYUP, VK_SHIFT, 1);
 end;
 
@@ -410,14 +448,34 @@ begin
   F_space.Caption := '____________________';
   F_space.Parent := FRow4;
   F_space.OnMouseDown := OnButtonClick;
+
+  Screen.AddHandlerActiveControlChanged(ScreenActiveControlChanged);
 end;
 
 destructor TBCKeyboard.Destroy;
 begin
+  Screen.RemoveHandlerActiveControlChanged(ScreenActiveControlChanged);
   { Everything inside the panel will be freed }
   FPanel.Free;
   inherited Destroy;
 end;
+
+{$IFDEF lclGTK2}procedure TBCKeyboard.ScreenActiveControlChanged(Sender: TObject; LastControl: TControl);
+begin
+  if (LastControl = nil) or (LastControl is TWinControl) then
+  begin
+    if (LastControl <> FRow1) and (LastControl <> FRow2) and (LastControl <> FRow3) and (LastControl <> FRow4) then
+       FActiveControl := TWinControl(LastControl)
+    else
+      Application.QueueAsyncCall(ReactivateControl, 0);
+  end;
+end;
+
+procedure TBCKeyboard.ReactivateControl(Data: PtrInt);
+begin
+  if (FActiveControl <> nil) then
+    FActiveControl.SetFocus;
+end;{$ENDIF}
 
 procedure TBCKeyboard.Show(AControl: TWinControl);
 begin

--- a/test/test_bckeyboard/umain.pas
+++ b/test/test_bckeyboard/umain.pas
@@ -34,6 +34,7 @@ implementation
 
 procedure TForm1.FormShow(Sender: TObject);
 begin
+  Edit1.AutoSize := true;
   BCDefaultThemeManager1.Apply();
   BCKeyboard1.PanelsColor := $00535353;
   BCKeyboard1.Panel.Left := 0;


### PR DESCRIPTION
The idea is to prevent the BCKeyboard component to be focused and to send all different messages for the key inputs (`KEYDOWN`, `KEYCHAR`, `Utf8KeyPress`, `KEYUP`).

This continues the original pull request #266.

I've tested it on Windows and on WSL (gtk2).

On Windows, sending the `KEYCHAR` event automatically generates the `Utf8KeyPress` call, whereas on Linux with gtk2 I've added an explicit call to this method.